### PR TITLE
Add ALSA receiver

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ discrete sound device. Audio played through this device is
 published on your local network as a PCM multicast stream.
 
 Receivers on the network can pick up the stream and play it
-through their own audio outputs. A simple server for Linux
-(interfacing with PulseAudio) and one for Windows are provided.
+through their own audio outputs. Two simple servers for Linux
+(interfacing with PulseAudio or ALSA) and one for Windows are
+provided.
 
 Scream is based on Microsoft's MSVAD audio driver sample code.
 
@@ -46,15 +47,18 @@ usually sufficient to just open a multicast listen socket and
 start reading from it. Minimal buffering (~ 4 times the UDP
 payload size) should be done to account for jitter.
 
-Two receivers are provided: 
+Three receivers are provided: 
 
 - Linux/Pulseaudio: Not included in the installer package. Just
 type 'make' to build it.
 
+- Linux/ALSA: Not included in the installer package. Just type
+'make' to build it.
+
 - Windows: ScreamReader, contributed by @MrShoenel. Included in
 the installer package as of version 1.2.
 
-Both receivers can be run as unprivileged users.
+All three receivers can be run as unprivileged users.
 
 
 Building

--- a/Receivers/alsa/Makefile
+++ b/Receivers/alsa/Makefile
@@ -1,0 +1,5 @@
+CC=gcc
+CFLAGS = -Wall -O2
+
+scream-alsa: scream-alsa.c
+	$(CC) $(CFLAGS) -o scream-alsa scream-alsa.c -lasound

--- a/Receivers/alsa/README.md
+++ b/Receivers/alsa/README.md
@@ -1,0 +1,38 @@
+# scream-alsa
+
+scream-alsa is a scream receiver using ALSA as audio output.
+
+## Compile
+
+You need asound headers in advance.
+
+```shell
+$ sudo yum install alsa-lib-devel # Redhat, CentOS, etc.
+or
+$ sudo apt-get install libasound2-dev # Debian, Ubuntu, etc.
+```
+
+Run `make` command.
+
+## Usage
+
+```shell
+$ scream-alsa
+```
+
+If your machine has more than one network interface, you may need to
+set the interface name which receives scream packets.
+
+```shell
+$ scream-alsa -i eth0
+```
+
+If you experience excessive underruns under normal operating conditions,
+lower the process niceness; if it still underruns, raise the default
+output start threshold (1960) with `-t`:
+
+```shell
+$ scream-alsa -t 7840
+```
+
+Run with `env LIBASOUND_DEBUG=1` to debug ALSA problems.

--- a/Receivers/alsa/scream-alsa.c
+++ b/Receivers/alsa/scream-alsa.c
@@ -1,0 +1,199 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <alsa/asoundlib.h>
+
+#include <unistd.h>
+#include <sys/socket.h>
+#include <sys/ioctl.h>
+#include <net/if.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+
+#define MULTICAST_TARGET "239.255.77.77"
+#define MULTICAST_PORT 4010
+#define MAX_SO_PACKETSIZE 1764
+#define BYTES_PER_SAMPLE 2
+#define CHANNELS 2
+#define TYPICAL_SAMPLES_PER_PACKET (980 / (BYTES_PER_SAMPLE * CHANNELS))
+
+#define SNDCHK(call, ret) { \
+  if (ret < 0) {            \
+    alsa_error(call, ret);  \
+    return -1;              \
+  }                         \
+}
+
+static void alsa_error(const char *msg, int r)
+{
+  fprintf(stderr, "%s: %s\n", msg, snd_strerror(r));
+}
+
+static void show_usage(const char *arg0)
+{
+  fprintf(stderr, "Usage: %s [-i interface_name_or_address] [-t alsa_output_start_threshold]\n",
+	  arg0);
+  exit(1);
+}
+
+static in_addr_t get_interface(const char *name)
+{
+  int sockfd = socket(AF_INET, SOCK_DGRAM, 0);
+  struct ifreq ifr;
+  in_addr_t addr = inet_addr(name);
+  struct if_nameindex *ni;
+  int i;
+
+  if (addr != INADDR_NONE) {
+    return addr;
+  }
+
+  if (strlen(name) >= sizeof(ifr.ifr_name)) {
+    fprintf(stderr, "Too long interface name: %s\n\n", name);
+    goto error_exit;
+  }
+  strcpy(ifr.ifr_name, name);
+
+  sockfd = socket(AF_INET, SOCK_DGRAM, 0);
+  if (ioctl(sockfd, SIOCGIFADDR, &ifr) != 0) {
+    fprintf(stderr, "Invalid interface: %s\n\n", name);
+    goto error_exit;
+  }
+  close(sockfd);
+  return ((struct sockaddr_in *)&ifr.ifr_addr)->sin_addr.s_addr;
+
+error_exit:
+  ni = if_nameindex();
+  fprintf(stderr, "Available interfaces:\n");
+  for (i = 0; ni[i].if_name != NULL; i++) {
+    strcpy(ifr.ifr_name, ni[i].if_name);
+    if (ioctl(sockfd, SIOCGIFADDR, &ifr) == 0) {
+      fprintf(stderr, "  %-10s (%s)\n", ni[i].if_name, inet_ntoa(((struct sockaddr_in *)&ifr.ifr_addr)->sin_addr));
+    }
+  }
+  exit(1);
+}
+
+static int setup_alsa(snd_pcm_t *pcm, unsigned int rate, unsigned int channels, int start_threshold)
+{
+  int ret;
+  snd_pcm_hw_params_t *hw;
+  snd_pcm_sw_params_t *sw;
+
+  snd_pcm_hw_params_alloca(&hw);
+
+  ret = snd_pcm_hw_params_any(pcm, hw);
+  SNDCHK("snd_pcm_hw_params_any", ret);
+
+  ret = snd_pcm_hw_params_set_rate_resample(pcm, hw, 1);
+  SNDCHK("snd_pcm_hw_params_set_rate_resample", ret);
+
+  ret = snd_pcm_hw_params_set_access(pcm, hw, SND_PCM_ACCESS_RW_INTERLEAVED);
+  SNDCHK("snd_pcm_hw_params_set_access", ret);
+
+  ret = snd_pcm_hw_params_set_format(pcm, hw, SND_PCM_FORMAT_S16_LE);
+  SNDCHK("snd_pcm_hw_params_set_format", ret);
+
+  ret = snd_pcm_hw_params_set_rate_near(pcm, hw, &rate, 0);
+  SNDCHK("snd_pcm_hw_params_set_rate_near", ret);
+
+  ret = snd_pcm_hw_params_set_channels(pcm, hw, channels);
+  SNDCHK("snd_pcm_hw_params_set_channels", ret);
+
+  ret = snd_pcm_hw_params(pcm, hw);
+  SNDCHK("hw_params", ret);
+
+  ret = snd_pcm_prepare(pcm);
+  SNDCHK("snd_pcm_prepare", ret);
+
+  snd_pcm_sw_params_alloca(&sw);
+
+  ret = snd_pcm_sw_params_current(pcm, sw);
+  SNDCHK("snd_pcm_sw_params_current", ret);
+
+  // Avoid underruns
+  ret = snd_pcm_sw_params_set_start_threshold(pcm, sw, start_threshold);
+  SNDCHK("snd_pcm_sw_params_set_start_threshold", ret);
+
+  ret = snd_pcm_sw_params(pcm, sw);
+  SNDCHK("snd_pcm_sw_params", ret);
+
+  return 0;
+}
+
+static int write_frames(snd_pcm_t *snd, void *pcm, int num_frames)
+{
+  int ret;
+  snd_pcm_sframes_t f;
+
+  f = snd_pcm_writei(snd, pcm, num_frames);
+  if (f < 0) {
+    ret = snd_pcm_recover(snd, f, 0);
+    SNDCHK("snd_pcm_recover", ret);
+    return 0;
+  }
+  if (f < num_frames) {
+    fprintf(stderr, "Short write %ld\n", f);
+  }
+  return num_frames;
+}
+
+int main(int argc, char *argv[])
+{
+  int sockfd, ret;
+  ssize_t n;
+  struct sockaddr_in servaddr;
+  struct ip_mreq imreq;
+  snd_pcm_t *snd;
+  unsigned char buf[MAX_SO_PACKETSIZE];
+  in_addr_t interface = INADDR_ANY;
+  int opt;
+  unsigned int rate = 44100;
+  int samples;
+  int start_threshold = TYPICAL_SAMPLES_PER_PACKET * 8;
+
+  while ((opt = getopt(argc, argv, "i:t:")) != -1) {
+    switch (opt) {
+    case 'i':
+      interface = get_interface(optarg);
+      break;
+    case 't':
+      start_threshold = atoi(optarg);
+      break;
+    default:
+      show_usage(argv[0]);
+    }
+  }
+  if (optind < argc) {
+    fprintf(stderr, "Expected argument after options\n");
+    show_usage(argv[0]);
+  }
+
+  const char *device = "default";
+  ret = snd_pcm_open(&snd, device, SND_PCM_STREAM_PLAYBACK, 0);
+  SNDCHK("snd_pcm_open", ret);
+
+  if (setup_alsa(snd, rate, CHANNELS, start_threshold) == -1) {
+    return -1;
+  }
+
+  sockfd = socket(AF_INET, SOCK_DGRAM, 0);
+
+  memset((void *)&servaddr, 0, sizeof(servaddr));
+  servaddr.sin_family = AF_INET;
+  servaddr.sin_addr.s_addr = htonl(INADDR_ANY);
+  servaddr.sin_port = htons(MULTICAST_PORT);
+  bind(sockfd, (struct sockaddr *)&servaddr, sizeof(servaddr));
+
+  imreq.imr_multiaddr.s_addr = inet_addr(MULTICAST_TARGET);
+  imreq.imr_interface.s_addr = interface;
+
+  setsockopt(sockfd, IPPROTO_IP, IP_ADD_MEMBERSHIP, 
+             (const void *)&imreq, sizeof(struct ip_mreq));
+
+  for (;;) {
+    n = recvfrom(sockfd, &buf, MAX_SO_PACKETSIZE, 0, NULL, 0);
+    samples = n / (BYTES_PER_SAMPLE * CHANNELS);
+    write_frames(snd, &buf, samples);
+  }
+}


### PR DESCRIPTION
Hi Tom,

First, I want to say I love Scream, thank you for publishing it. I tried everything for getting audio out of my Windows VM (including USB audio devices and DisplayPort audio) and Scream is the only thing that worked properly.

I had some issues with Wine applications suddenly stopping audio playback when using pulseaudio, and Scream is the only reason I had pulseaudio installed, so I wrote an ALSA receiver based on the existing pulseaudio receiver.  It is working pretty well here.  But if you don't want it, no problem, I can maintain it elsewhere.

I tested to make sure left/right is correct and that the latency is about the same as with the pulseaudio receiver.

I am not a C or ALSA expert, so please let me know if I missed something.

Thanks,

Ivan