### PR TITLE
ALSA receiver improvements

### DIFF
--- a/Receivers/alsa/README.md
+++ b/Receivers/alsa/README.md
@@ -29,11 +29,14 @@ $ scream-alsa -i eth0
 
 If you experience excessive underruns under normal operating conditions,
 lower the process niceness; if it still underruns, raise the default
-output start threshold (1960) with `-t`:
+target latency (50 ms) with `-t`:
 
 ```shell
-$ scream-alsa -t 7840
+$ scream-alsa -t 100
 ```
+
+Note that audio hardware typically has small buffers that result in a
+latency lower than the target latency.
 
 Run with `-v` to dump ALSA PCM setup information.
 

--- a/Receivers/alsa/README.md
+++ b/Receivers/alsa/README.md
@@ -35,4 +35,6 @@ output start threshold (1960) with `-t`:
 $ scream-alsa -t 7840
 ```
 
+Run with `-v` to dump ALSA PCM setup information.
+
 Run with `env LIBASOUND_DEBUG=1` to debug ALSA problems.

--- a/Receivers/alsa/scream-alsa.c
+++ b/Receivers/alsa/scream-alsa.c
@@ -74,12 +74,21 @@ error_exit:
   exit(1);
 }
 
-static void dump_alsa_info(snd_pcm_t *pcm)
+static int dump_alsa_info(snd_pcm_t *pcm)
 {
+  int ret;
   snd_output_t *log;
-  snd_output_stdio_attach(&log, stderr, 0);
-  snd_pcm_dump(pcm, log);
-  snd_output_close(log);
+
+  ret = snd_output_stdio_attach(&log, stderr, 0);
+  SNDCHK("snd_output_stdio_attach", ret);
+
+  ret = snd_pcm_dump(pcm, log);
+  SNDCHK("snd_pcm_dump", ret);
+
+  ret = snd_output_close(log);
+  SNDCHK("snd_output_close", ret);
+
+  return 0;
 }
 
 static int setup_alsa(snd_pcm_t *pcm, unsigned int rate, int verbosity, unsigned int target_latency_ms)
@@ -93,7 +102,7 @@ static int setup_alsa(snd_pcm_t *pcm, unsigned int rate, int verbosity, unsigned
   SNDCHK("snd_pcm_set_params", ret);
 
   if (verbosity > 0) {
-    dump_alsa_info(pcm);
+    return dump_alsa_info(pcm);
   }
 
   return 0;

--- a/Receivers/alsa/scream-alsa.c
+++ b/Receivers/alsa/scream-alsa.c
@@ -15,7 +15,6 @@
 #define MAX_SO_PACKETSIZE 1764
 #define BYTES_PER_SAMPLE 2
 #define CHANNELS 2
-#define TYPICAL_SAMPLES_PER_PACKET (980 / (BYTES_PER_SAMPLE * CHANNELS))
 
 #define SNDCHK(call, ret) { \
   if (ret < 0) {            \

--- a/Receivers/alsa/scream-alsa.c
+++ b/Receivers/alsa/scream-alsa.c
@@ -82,7 +82,7 @@ static void dump_alsa_info(snd_pcm_t *pcm)
   snd_output_close(log);
 }
 
-static int setup_alsa(snd_pcm_t *pcm, unsigned int rate, unsigned int channels, int start_threshold, int verbosity)
+static int setup_alsa(snd_pcm_t *pcm, unsigned int rate, int start_threshold, int verbosity)
 {
   int ret;
   snd_pcm_hw_params_t *hw;
@@ -105,7 +105,7 @@ static int setup_alsa(snd_pcm_t *pcm, unsigned int rate, unsigned int channels, 
   ret = snd_pcm_hw_params_set_rate_near(pcm, hw, &rate, 0);
   SNDCHK("snd_pcm_hw_params_set_rate_near", ret);
 
-  ret = snd_pcm_hw_params_set_channels(pcm, hw, channels);
+  ret = snd_pcm_hw_params_set_channels(pcm, hw, CHANNELS);
   SNDCHK("snd_pcm_hw_params_set_channels", ret);
 
   ret = snd_pcm_hw_params(pcm, hw);
@@ -189,7 +189,7 @@ int main(int argc, char *argv[])
   ret = snd_pcm_open(&snd, device, SND_PCM_STREAM_PLAYBACK, 0);
   SNDCHK("snd_pcm_open", ret);
 
-  if (setup_alsa(snd, rate, CHANNELS, start_threshold, verbosity) == -1) {
+  if (setup_alsa(snd, rate, start_threshold, verbosity) == -1) {
     return -1;
   }
 


### PR DESCRIPTION
- Use `snd_pcm_set_params` to set up the PCM, which should work better on audio devices with unusually small or large buffers.
- Add a `-v` option to see the parameters that ALSA chose.
- Change `-t` to be a target latency instead of a strange ALSA start threshold
- Finish the rare short writes

Thanks for debianuser in freenode #alsa for explaining how to actually use all this ALSA stuff.