### PR TITLE
Fix for #41 - BSOD if no IVSHMEM device is found but UseIVSHMEM is set

### DIFF
--- a/Scream/ivshmemsavedata.cpp
+++ b/Scream/ivshmemsavedata.cpp
@@ -20,6 +20,10 @@
 
 //=============================================================================
 BOOLEAN CIVSHMEMSaveData::RequestMMAP() {
+	if (!m_ivshmem.devObj) {
+		return FALSE;
+	}
+
     IO_STATUS_BLOCK ioStatus = { 0 };
     KEVENT event;
     KeInitializeEvent(&event, NotificationEvent, FALSE);
@@ -51,6 +55,10 @@ BOOLEAN CIVSHMEMSaveData::RequestMMAP() {
 
 //=============================================================================
 void CIVSHMEMSaveData::ReleaseMMAP() {
+	if (!m_ivshmem.devObj) {
+		return;
+	}
+
     IO_STATUS_BLOCK ioStatus = { 0 };
     KEVENT event;
     KeInitializeEvent(&event, NotificationEvent, FALSE);


### PR DESCRIPTION
Hi @duncanthrax ,
I'm merging this fix for a stupid bug I made in IVSHMEM that was reported in #41 

I've tested it on 2 VMs and it seems to work fine.

When you have time can you sign and release it?

Thanks