### PR TITLE
No need to open IVSHMEM in write mode

### DIFF
--- a/Receivers/alsa-ivshmem/scream-ivshmem-alsa.c
+++ b/Receivers/alsa-ivshmem/scream-ivshmem-alsa.c
@@ -141,7 +141,7 @@ static void * open_mmap(const char *shmfile) {
     exit(3);
   }
 
-  void * map = mmap(0, st.st_size, PROT_READ | PROT_WRITE, MAP_SHARED, shmFD, 0);
+  void * map = mmap(0, st.st_size, PROT_READ, MAP_SHARED, shmFD, 0);
   if (map == MAP_FAILED) {
     fprintf(stderr, "Failed to map the shared memory file: %s", shmfile);
     close(shmFD);

--- a/Receivers/pulseaudio-ivshmem/scream-ivshmem-pulse.c
+++ b/Receivers/pulseaudio-ivshmem/scream-ivshmem-pulse.c
@@ -36,7 +36,7 @@ static void * open_mmap(const char *shmfile) {
     exit(3);
   }
 
-  void * map = mmap(0, st.st_size, PROT_READ | PROT_WRITE, MAP_SHARED, shmFD, 0);
+  void * map = mmap(0, st.st_size, PROT_READ, MAP_SHARED, shmFD, 0);
   if (map == MAP_FAILED) {
     fprintf(stderr, "Failed to map the shared memory file: %s", shmfile);
     close(shmFD);

--- a/Receivers/raw-ivshmem/scream-ivshmem-raw.c
+++ b/Receivers/raw-ivshmem/scream-ivshmem-raw.c
@@ -46,7 +46,7 @@ static void * open_mmap(const char *shmfile) {
     exit(3);
   }
 
-  void * map = mmap(0, st.st_size, PROT_READ | PROT_WRITE, MAP_SHARED, shmFD, 0);
+  void * map = mmap(0, st.st_size, PROT_READ, MAP_SHARED, shmFD, 0);
   if (map == MAP_FAILED) {
     fprintf(stderr, "Failed to map the shared memory file: %s", shmfile);
     close(shmFD);


### PR DESCRIPTION
As pointed out in #43 the receiver fail to open the IVSHMEM device if the user don't have write permission.
Write permission was needed in an earlier version that was never published. There is no need to open the IVSHMEM device with write mode.
