### PR TITLE
No need to open IVSHMEM in write mode

### DIFF
--- a/Receivers/alsa-ivshmem/scream-ivshmem-alsa.c
+++ b/Receivers/alsa-ivshmem/scream-ivshmem-alsa.c
@@ -131,19 +131,19 @@ static int write_frames(snd_pcm_t *snd, unsigned char *buf, int total_frames, in
 static void * open_mmap(const char *shmfile) {
   struct stat st;
   if (stat(shmfile, &st) < 0)  {
-    fprintf(stderr, "Failed to stat the shared memory file: %s", shmfile);
+    fprintf(stderr, "Failed to stat the shared memory file: %s\n", shmfile);
     exit(2);
   }
 
-  int shmFD = open(shmfile, O_RDWR, (mode_t)0600);
+  int shmFD = open(shmfile, O_RDONLY);
   if (shmFD < 0) {
-    fprintf(stderr, "Failed to open the shared memory file: %s", shmfile);
+    fprintf(stderr, "Failed to open the shared memory file: %s\n", shmfile);
     exit(3);
   }
 
   void * map = mmap(0, st.st_size, PROT_READ, MAP_SHARED, shmFD, 0);
   if (map == MAP_FAILED) {
-    fprintf(stderr, "Failed to map the shared memory file: %s", shmfile);
+    fprintf(stderr, "Failed to map the shared memory file: %s\n", shmfile);
     close(shmFD);
     exit(4);
   }

--- a/Receivers/pulseaudio-ivshmem/scream-ivshmem-pulse.c
+++ b/Receivers/pulseaudio-ivshmem/scream-ivshmem-pulse.c
@@ -26,19 +26,19 @@ static void show_usage(const char *arg0)
 static void * open_mmap(const char *shmfile) {
   struct stat st;
   if (stat(shmfile, &st) < 0)  {
-    fprintf(stderr, "Failed to stat the shared memory file: %s", shmfile);
+    fprintf(stderr, "Failed to stat the shared memory file: %s\n", shmfile);
     exit(2);
   }
 
-  int shmFD = open(shmfile, O_RDWR, (mode_t)0600);
+  int shmFD = open(shmfile, O_RDONLY);
   if (shmFD < 0) {
-    fprintf(stderr, "Failed to open the shared memory file: %s", shmfile);
+    fprintf(stderr, "Failed to open the shared memory file: %s\n", shmfile);
     exit(3);
   }
 
   void * map = mmap(0, st.st_size, PROT_READ, MAP_SHARED, shmFD, 0);
   if (map == MAP_FAILED) {
-    fprintf(stderr, "Failed to map the shared memory file: %s", shmfile);
+    fprintf(stderr, "Failed to map the shared memory file: %s\n", shmfile);
     close(shmFD);
     exit(4);
   }

--- a/Receivers/raw-ivshmem/scream-ivshmem-raw.c
+++ b/Receivers/raw-ivshmem/scream-ivshmem-raw.c
@@ -36,19 +36,19 @@ static void show_usage(const char *arg0)
 static void * open_mmap(const char *shmfile) {
   struct stat st;
   if (stat(shmfile, &st) < 0)  {
-    fprintf(stderr, "Failed to stat the shared memory file: %s", shmfile);
+    fprintf(stderr, "Failed to stat the shared memory file: %s\n", shmfile);
     exit(2);
   }
 
-  int shmFD = open(shmfile, O_RDWR, (mode_t)0600);
+  int shmFD = open(shmfile, O_RDONLY);
   if (shmFD < 0) {
-    fprintf(stderr, "Failed to open the shared memory file: %s", shmfile);
+    fprintf(stderr, "Failed to open the shared memory file: %s\n", shmfile);
     exit(3);
   }
 
   void * map = mmap(0, st.st_size, PROT_READ, MAP_SHARED, shmFD, 0);
   if (map == MAP_FAILED) {
-    fprintf(stderr, "Failed to map the shared memory file: %s", shmfile);
+    fprintf(stderr, "Failed to map the shared memory file: %s\n", shmfile);
     close(shmFD);
     exit(4);
   }


### PR DESCRIPTION
I forgot to change a line in my last pull request (O_RDWR to O_RDONLY), plus I'm adding newlines to mmap related error messages.