### PR TITLE
Fixed a minor regression and improved documentations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ example:
   <address type='pci' domain='0x0000' bus='0x00' slot='0x11' function='0x0'/>
 </shmem>
 ```
+- Install the IVSHMEM driver from [here](https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/upstream-virtio/).
 - To make the driver use IVSHMEM, add a DWORD `HKLM\SYSTEM\CurrentControlSet\Services\Scream\Options\UseIVSHMEM`,
 with the value being the size of the device in MB (2, as recommended). Please
 note that scream will identify the device by its size, so you should only

--- a/Scream/minwave.cpp
+++ b/Scream/minwave.cpp
@@ -529,9 +529,9 @@ Return Value:
                         else if ((pWfx->wFormatTag == WAVE_FORMAT_EXTENSIBLE) && (pWfx->cbSize == CB_EXTENSIBLE)) {
                             WAVEFORMATEXTENSIBLE* pWfxT = (WAVEFORMATEXTENSIBLE*)pWfx;
                             // The channel mask can be greater than 0x07FF, but only in exotic configurations.
-                            // It's important that the number of channels is even, to fit in PCM_PAYLOAD_SIZE. The only known case of odd number is 6.1 surround.
+                            // It's important that the number of channels is even, to fit in PCM_PAYLOAD_SIZE. Mono is an exception.
                             // This restriction doesn't apply if IVSHMEM is used, because the packet size is dynamic there.
-                            if ((pWfx->nChannels >= 1) && (pWfx->nChannels <= 8) && (pWfxT->dwChannelMask <= 0x07FF) && (g_UseIVSHMEM || pWfx->nChannels % 2 == 0)) {
+                            if ((pWfx->nChannels >= 1) && (pWfx->nChannels <= 8) && (pWfxT->dwChannelMask <= 0x07FF) && (g_UseIVSHMEM || pWfx->nChannels == 1 || pWfx->nChannels % 2 == 0)) {
                                 ntStatus = STATUS_SUCCESS;
                             }
                         }


### PR DESCRIPTION
Hi @duncanthrax ,
I'm fixing a minor regression that I introduced a couple of commits ago where in the network version of scream I removed support for odd number of channels.
This was to remove support for 6.1 surround because it was not possible to fit it perfectly into a network packet of fixed size without some sort of padding. I didn't realize at the time that mono was also removed and an user requested to fix this in #47 

I've also added a line in the redme to let users know that they also need to install the driver for the IVSHMEM device for Scream to work. This was reported in #43 and by a couple of users on reddit.

Since the changes are trivial I'm merging them, when you have time can you release a new signed version so we can close #47 ?

Thanks.