### PR TITLE
Exit with an error if pulse audio connection fails

### DIFF
--- a/Receivers/pulseaudio-ivshmem/scream-ivshmem-pulse.c
+++ b/Receivers/pulseaudio-ivshmem/scream-ivshmem-pulse.c
@@ -91,10 +91,10 @@ int main(int argc, char*argv[]) {
     &ss,
     &channel_map,
     NULL,
-    NULL
+    &error
   );
   if (!s) {
-    printf("Unable to connect to PulseAudio.\n");
+    fprintf(stderr, "Unable to connect to PulseAudio. %s\n", pa_strerror(error));
     goto BAIL;
   }
   
@@ -233,12 +233,12 @@ int main(int argc, char*argv[]) {
     }
     if (!ss.rate) continue;
     if (pa_simple_write(s, buf, header->chunk_size, &error) < 0) {
-      printf("pa_simple_write() failed: %s\n", pa_strerror(error));
+      fprintf(stderr, "pa_simple_write() failed: %s\n", pa_strerror(error));
       goto BAIL;
     }
   }
 
   BAIL:
-  if (s) pa_simple_free(s);
-  return 0;
+    if (s) pa_simple_free(s);
+    return 1;
 };

--- a/Receivers/pulseaudio/scream-pulse.c
+++ b/Receivers/pulseaudio/scream-pulse.c
@@ -137,10 +137,10 @@ int main(int argc, char*argv[]) {
     &ss,
     &channel_map,
     NULL,
-    NULL
+    &error
   );
   if (!s) {
-    printf("Unable to connect to PulseAudio\n");
+    fprintf(stderr, "Unable to connect to PulseAudio. %s\n", pa_strerror(error));
     goto BAIL;
   }
 
@@ -274,13 +274,13 @@ int main(int argc, char*argv[]) {
       }
       if (!ss.rate) continue;
       if (pa_simple_write(s, &buf[HEADER_SIZE], n - HEADER_SIZE, &error) < 0) {
-        printf("pa_simple_write() failed: %s\n", pa_strerror(error));
+        fprintf(stderr, "pa_simple_write() failed: %s\n", pa_strerror(error));
         goto BAIL;
       }
     }
   }
 
   BAIL:
-  if (s) pa_simple_free(s);
-  return 0;
+    if (s) pa_simple_free(s);
+    return 1;
 };


### PR DESCRIPTION
I had a hard time debugging, why scream-ivshmem-pulse would not start when run by a libvirt hook. Unable to get any output, I quickly checked the source and found it always exits with 0, thus not displaying an error.

Changed exit code on error to 1
Changed printf to fprintf to print to stderr

edit: just checked the pulseaudio receiver and did the same there.