### PR TITLE
Add PulseAudio application icon hint

### DIFF
--- a/Receivers/pulseaudio-ivshmem/scream-ivshmem-pulse.c
+++ b/Receivers/pulseaudio-ivshmem/scream-ivshmem-pulse.c
@@ -82,6 +82,9 @@ int main(int argc, char*argv[]) {
   // higher load conditions. This may fail when run as non-root.
   setpriority(PRIO_PROCESS, 0, -11);
 
+  // set application icon
+  setenv("PULSE_PROP_application.icon_name", "audio-card", 0);
+
   // map to stereo, it's the default number of channels
   pa_channel_map_init_stereo(&channel_map);
 

--- a/Receivers/pulseaudio/scream-pulse.c
+++ b/Receivers/pulseaudio/scream-pulse.c
@@ -128,6 +128,9 @@ int main(int argc, char*argv[]) {
   // higher load conditions. This may fail when run as non-root.
   setpriority(PRIO_PROCESS, 0, -11);
 
+  // set application icon
+  setenv("PULSE_PROP_application.icon_name", "audio-card", 0);
+
   // map to stereo, it's the default number of channels
   pa_channel_map_init_stereo(&channel_map);
 


### PR DESCRIPTION
This allows other pulseaudio clients to render a suitable icon (e.g. KDE volume control)