### PR TITLE
Add target latency option to pulseaudio receiver

### DIFF
--- a/Receivers/pulseaudio/Makefile
+++ b/Receivers/pulseaudio/Makefile
@@ -1,5 +1,5 @@
 CC=gcc
-CFLAGS = -Wall
+CFLAGS = -Wall -O2
 
 scream-pulse: scream-pulse.c
 	$(CC) $(CFLAGS) -o scream-pulse scream-pulse.c -lpulse-simple -lpulse


### PR DESCRIPTION
This PR adds the `-t <latency>` command line option to the pulseaudio receiver.

This option allows me reduce the audio latency on the receiver side from ~200ms to ~30ms without any hiccups, using a Raspberry Pi 2 with an IQaudIO Pi-DAC+ sound card.

Note that it depends on your specific software and hardware setup whether this option will have any effect. See for instance: https://www.freedesktop.org/wiki/Software/PulseAudio/Documentation/Developer/Clients/LatencyControl/