### PR TITLE
new option to pass stream name/description to pulseaudio

### DIFF
--- a/Receivers/unix/pulseaudio.c
+++ b/Receivers/unix/pulseaudio.c
@@ -8,9 +8,10 @@ static struct pulse_output_data {
 
   receiver_format_t receiver_format;
   int latency;
+  char *stream_name;
 } po_data;
 
-int pulse_output_init(int latency)
+int pulse_output_init(int latency, char *stream_name)
 {
   int error;
 
@@ -32,6 +33,7 @@ int pulse_output_init(int latency)
   po_data.receiver_format.channel_map = 0x0003;
 
   po_data.latency = latency;
+  po_data.stream_name = stream_name;
 
   // set buffer size for requested latency
   po_data.buffer_attr.maxlength = (uint32_t)-1;
@@ -44,7 +46,7 @@ int pulse_output_init(int latency)
     "Scream",
     PA_STREAM_PLAYBACK,
     NULL,
-    "Audio",
+    po_data.stream_name,
     &po_data.ss,
     &po_data.channel_map,
     &po_data.buffer_attr,
@@ -161,7 +163,7 @@ int pulse_output_send(receiver_data_t *data)
         "Scream",
         PA_STREAM_PLAYBACK,
         NULL,
-        "Audio",
+        po_data.stream_name,
         &po_data.ss,
         &po_data.channel_map,
         &po_data.buffer_attr,

--- a/Receivers/unix/pulseaudio.h
+++ b/Receivers/unix/pulseaudio.h
@@ -10,7 +10,7 @@
 
 #include "scream.h"
 
-int pulse_output_init(int latency);
+int pulse_output_init(int latency, char *stream_name);
 int pulse_output_send(receiver_data_t *data);
 
 #endif

--- a/Receivers/unix/scream.c
+++ b/Receivers/unix/scream.c
@@ -47,6 +47,7 @@ static void show_usage(const char *arg0)
   fprintf(stderr, "\n");
   fprintf(stderr, "         -o pulse|alsa|raw         : Send audio to PulseAudio, ALSA, or stdout.\n");
   fprintf(stderr, "         -d <device>               : ALSA device name. 'default' if not specified.\n");
+  fprintf(stderr, "         -n <stream name>          : Pulseaudio stream name/description.\n");
   fprintf(stderr, "         -t <latency>              : Target latency in milliseconds. Defaults to 50ms.\n");
   fprintf(stderr, "                                     Only relevant for PulseAudio and ALSA output.\n");
   fprintf(stderr, "\n");
@@ -119,12 +120,13 @@ int main(int argc, char*argv[]) {
   char *ivshmem_device  = NULL;
   char *output          = NULL;
   char *alsa_device     = "default";
+  char *stream_name     = "Audio";
   int target_latency_ms = 50;
   in_addr_t interface   = INADDR_ANY;
   uint16_t port         = DEFAULT_PORT;
 
   int opt;
-  while ((opt = getopt(argc, argv, "i:g:p:m:o:d:t:uvh")) != -1) {
+  while ((opt = getopt(argc, argv, "i:g:p:m:o:d:n:t:uvh")) != -1) {
     switch (opt) {
     case 'i':
       interface = get_interface(optarg);
@@ -152,6 +154,9 @@ int main(int argc, char*argv[]) {
     case 'd':
       alsa_device = strdup(optarg);
       break;
+    case 'n':
+      stream_name = strdup(optarg);
+      break;
     case 't':
       target_latency_ms = atoi(optarg);
       if (target_latency_ms < 0) show_usage(argv[0]);
@@ -177,7 +182,7 @@ int main(int argc, char*argv[]) {
     case Pulseaudio:
 #ifdef PULSEAUDIO_ENABLE
       if (verbosity) fprintf(stderr, "Using Pulseaudio output\n");
-      if (pulse_output_init(target_latency_ms) != 0) {
+      if (pulse_output_init(target_latency_ms, stream_name) != 0) {
         return 1;
       }
       output_send_fn = pulse_output_send;


### PR DESCRIPTION
Handy to distinguish between clients, when having more than 1 receiver active.

```
$ ./scream -n "Local Win 10" &
$ ./scream -i eth0 -n "Multicast on eth0"
```