### PR TITLE
Stop requiring C++

### DIFF
--- a/Receivers/unix/CMakeLists.txt
+++ b/Receivers/unix/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.7)
 
-project(scream)
+project(scream LANGUAGES C)
 
 add_executable(${PROJECT_NAME} scream.c network.c shmem.c raw.c)
 


### PR DESCRIPTION
project() defaults to C and C++