### PR TITLE
Ensure we aren't too far behind the write index

### DIFF
--- a/Receivers/unix/shmem.c
+++ b/Receivers/unix/shmem.c
@@ -29,6 +29,10 @@ int init_shmem(char* shmem_device_file)
   return 0;
 }
 
+int32_t mod(int32_t x, int32_t N){
+    return (x % N + N) %N;
+}
+
 void rcv_shmem(receiver_data_t* receiver_data)
 {
   struct shmheader *header = (struct shmheader*)rctx_shmem.mmap;
@@ -54,6 +58,10 @@ void rcv_shmem(receiver_data_t* receiver_data)
 
   if (++rctx_shmem.read_idx == header->max_chunks) {
     rctx_shmem.read_idx = 0;
+  }
+
+  if(mod(header->write_idx-rctx_shmem.read_idx, header->max_chunks) > 3){//we are too far behind, skip forward
+    rctx_shmem.read_idx = mod((header->write_idx-1), header->max_chunks);
   }
 
   receiver_data->format.sample_rate = header->sample_rate;


### PR DESCRIPTION
For testing, don't merge yet.

This is a complementary patch to #90 that limit the amount of chunks the receiver can be behind the write index of the ring buffer.

During normal operation I measured that the read index is exactly 1 chunk behind the write index.
Rarely it goes to 2 for just a loop or two.

Pushing the settings to the max (192khz, 8channels, 32 bit) make it goes up to 3 once in a while if `bcdedit /set useplatformclock true` is set. Disabling it helps a lot.

To make it go over 3 I have to use physlock or other methods as explained in #54 

The idea here is simply to catch that and reset the read index 1 chunk behind the write one.

It would be great to have a bit of feedback if 3 chunks (60ms) is a good value.