### PR TITLE
scream-pcap: libpcap mode for those that can only see their UDP multicasts in wireshark/tcpdump

### DIFF
--- a/Receivers/unix/CMakeLists.txt
+++ b/Receivers/unix/CMakeLists.txt
@@ -33,6 +33,20 @@ if (ALSA_ENABLE)
   endif ()
 endif ()
 
+# find libpcap
+option(PCAP_ENABLE "Enable PCAP" ON)
+if (PCAP_ENABLE)
+  find_package(PkgConfig)
+  pkg_check_modules(PC_PCAP libpcap)
+  if (PC_PCAP_FOUND)
+    include_directories(${PC_PCAP_INCLUDEDIR})
+    target_link_libraries(${PROJECT_NAME} ${PC_PCAP_LIBRARIES})
+    target_sources(${PROJECT_NAME} PRIVATE pcap.c)
+  else ()
+    set(PCAP_ENABLE OFF)
+  endif ()
+endif ()
+
 configure_file(config.h.in config.h)
 target_include_directories(${PROJECT_NAME} PUBLIC "${PROJECT_BINARY_DIR}")
 

--- a/Receivers/unix/README.md
+++ b/Receivers/unix/README.md
@@ -51,6 +51,23 @@ Unicast mode is also supported, and can be used by passing the -u option. If you
 $ scream -i eth0
 ```
 
+### libpcap mode
+
+This starts the Scream client in libpcap (sniffer) mode. This mode is mostly useful if you are able to the UDP
+multicast/unicast transmission in `wireshark`/`tcpdump` but unable to have it be delivered to the
+user-space Scream client.
+
+```shell
+$ scream -P -i macvtap0
+```
+
+If you have the hard requirement of having to run the receiver as non-root due to `pulseaudio`/`alsa`
+uid/gid issues, you can do the following:
+
+```shell
+# setcap cap_net_raw,cap_net_admin=eip ./scream
+```
+
 ### IVSHMEM (Shared memory) mode
 
 Make sure to have read permission for the shared memory device and execute

--- a/Receivers/unix/config.h.in
+++ b/Receivers/unix/config.h.in
@@ -1,2 +1,3 @@
 #cmakedefine01 PULSEAUDIO_ENABLE
 #cmakedefine01 ALSA_ENABLE
+#cmakedefine01 PCAP_ENABLE

--- a/Receivers/unix/pcap.c
+++ b/Receivers/unix/pcap.c
@@ -1,0 +1,104 @@
+#include "pcap.h"
+
+static pcap_t *handle;
+static int (*pcap_output_callback)(receiver_data_t* receiver_data);
+
+int init_pcap(const char* interface_name, int port, char* multicast_group) {
+  struct bpf_program fp;             /* The compiled filter expression */
+  bpf_u_int32 mask;                  /* The netmask of our sniffing device */
+  bpf_u_int32 net;                   /* The IP of our sniffing device */
+  char filter_exp[PCAP_ERRBUF_SIZE]; /* Large enough */
+  char errbuf[PCAP_ERRBUF_SIZE];     /* Error buffer for calls into libpcap */
+
+  handle = pcap_open_live(interface_name, PCAP_BUFSIZ, 1, 1000, errbuf);
+  if (handle == NULL) {
+      // If you have the hard requirement of having to run the receiver as non-root due to pulse/alsa uid/gid issues:
+      //    setcap cap_net_raw,cap_net_admin=eip ./scream
+    fprintf(stderr, "libpcap couldn't open device %s: %s\n", interface_name, errbuf);
+    return 1;
+  }
+
+  snprintf(filter_exp, PCAP_ERRBUF_SIZE, "udp port %d", port);
+  if (pcap_lookupnet(interface_name, &net, &mask, errbuf) == -1) {
+    fprintf(stderr, "WARN: libpcap couldn't get netmask for device %s (often okay to ignore, especially for macvtap)\n", interface_name);
+    net = 0;
+    mask = 0;
+  }
+
+  if (pcap_datalink(handle) != DLT_EN10MB) {
+    fprintf(stderr, "libpcap device %s doesn't provide Ethernet headers, not supported\n", interface_name);
+    return 2;
+  }
+
+  if (pcap_compile(handle, &fp, filter_exp, 0, net) == -1) {
+    fprintf(stderr, "libpcap parse filter %s: %s\n", filter_exp, pcap_geterr(handle));
+    return 3;
+  }
+  if (pcap_setfilter(handle, &fp) == -1) {
+    fprintf(stderr, "libpcap install filter %s: %s\n", filter_exp, pcap_geterr(handle));
+    return 4;
+  }
+}
+
+void pcap_callback(u_char *args, const struct pcap_pkthdr *header, const u_char *pkg)
+{
+  const struct sniff_ethernet *ethernet;  /* The ethernet header */
+  const struct sniff_ip *ip;              /* The IP header */
+  const struct sniff_udp *udp;            /* The UDP header */
+  u_char* payload;                        /* Packet payload */
+
+  int size_ip;
+  int size_udp;
+  int size_payload;
+
+  /* define ethernet header */
+  ethernet = (struct sniff_ethernet*)(pkg);
+
+  /* define/compute ip header offset */
+  ip = (struct sniff_ip*)(pkg + SIZE_ETHERNET);
+  size_ip = IP_HL(ip) * 4;
+
+  if (size_ip < 20) {
+    fprintf(stderr, "pcap captured a packet with invalid IP header length of %u\n", size_ip);
+    return;
+  }
+
+  /* define/compute udp header offset */
+  udp = (struct sniff_udp*)(pkg + SIZE_ETHERNET + size_ip);
+  size_udp = ntohs(udp->uh_ulen);
+
+  /* define/compute udp payload (daragram) offset */
+  payload = (u_char *)(pkg + SIZE_ETHERNET + size_ip + 8);
+
+  /* compute udp payload (datagram) size */
+  size_payload = ntohs(ip->ip_len) - (size_ip + 8);
+
+  if (size_payload == 0 || size_udp == 0) {
+    fprintf(stderr, "pcap captured a udp packet with (size_payload=%d, size_udp=%d)\n", size_payload, size_ip);
+    return;
+  }
+
+  receiver_data_t receiver_data = {0};
+  if (size_payload < HEADER_SIZE) {
+    fprintf(stderr, "WARN: received packet shorter than %d\n", HEADER_SIZE);
+    return;
+  }
+
+  receiver_data.format.sample_rate = payload[0];
+  receiver_data.format.sample_size = payload[1];
+  receiver_data.format.channels = payload[2];
+  receiver_data.format.channel_map = (payload[4] << 8u) | payload[3];
+  receiver_data.audio_size = size_payload - HEADER_SIZE;
+  receiver_data.audio = &payload[5];
+
+  int ret = pcap_output_callback(&receiver_data);
+  if (ret != 0) {
+    fprintf(stderr, "WARN: output function failed with %d\n", ret);
+  }
+}
+
+int run_pcap(int (*output_function)(receiver_data_t*))
+{
+  pcap_output_callback = output_function;
+  return pcap_loop(handle, -1, pcap_callback, NULL);
+}

--- a/Receivers/unix/pcap.h
+++ b/Receivers/unix/pcap.h
@@ -1,0 +1,51 @@
+#ifndef PCAP_H
+#define PCAP_H
+
+#include "network.h"
+#include "scream.h"
+#include <pcap.h>
+#include <ctype.h>
+
+#define PCAP_BUFSIZ PCAP_BUF_SIZE * 8
+#define SIZE_ETHERNET 14
+
+/* Ethernet addresses are 6 bytes */
+#define ETHER_ADDR_LEN	6
+
+
+struct sniff_ethernet {
+    u_char ether_dhost[ETHER_ADDR_LEN]; /* Destination host address */
+    u_char ether_shost[ETHER_ADDR_LEN]; /* Source host address */
+    u_short ether_type;                 /* IP? ARP? RARP? etc */
+};
+
+struct sniff_ip {
+    u_char ip_vhl;      /* version << 4 | header length >> 2 */
+    u_char ip_tos;      /* type of service */
+    u_short ip_len;     /* total length */
+    u_short ip_id;      /* identification */
+    u_short ip_off;     /* fragment offset field */
+#define IP_RF 0x8000        /* reserved fragment flag */
+#define IP_DF 0x4000        /* dont fragment flag */
+#define IP_MF 0x2000        /* more fragments flag */
+#define IP_OFFMASK 0x1fff   /* mask for fragmenting bits */
+    u_char ip_ttl;      /* time to live */
+    u_char ip_p;        /* protocol */
+    u_short ip_sum;     /* checksum */
+    struct in_addr ip_src,ip_dst; /* source and dest address */
+};
+#define IP_HL(ip)       (((ip)->ip_vhl) & 0x0f)
+#define IP_V(ip)        (((ip)->ip_vhl) >> 4)
+
+struct sniff_udp {
+    u_short uh_sport;               /* source port */
+    u_short uh_dport;               /* destination port */
+    u_short uh_ulen;                /* udp length */
+    u_short uh_sum;                 /* udp checksum */
+};
+
+int init_pcap(const char* interface_name, int port, char* multicast_group);
+
+int run_pcap(int (*output_function)(receiver_data_t*));
+
+#endif

--- a/Receivers/unix/scream.h
+++ b/Receivers/unix/scream.h
@@ -4,7 +4,7 @@
 #include <stdint.h>
 
 enum receiver_type {
-  Unicast, Multicast, SharedMem
+  Unicast, Multicast, SharedMem, Pcap
 };
 
 enum output_type {

--- a/Receivers/unix/shell.nix
+++ b/Receivers/unix/shell.nix
@@ -1,0 +1,5 @@
+with import <nixpkgs> {};
+stdenv.mkDerivation {
+    name = "dev-environment";
+    buildInputs = [ pkgconfig libpcap alsaLib pulseaudio cmake ];
+}


### PR DESCRIPTION
This allows the Scream client to be started in libpcap (sniffer) mode.

Mostly useful if you are not a part of the lucky group to have their UDP multicast packets be successfully delivered to the user-space applications by their kernel.

If you are able to see the UDP multicast/unicast transmission of `scream` in `wireshark`/`tcpdump` but unable to have it be delivered to the user-space `scream` client (or `netcat`, even), you're a part of this group. You tried everything from disabling hardware offloading for UDP checksums to adjusting `net.*.mc_forwarding` or `net.*.rp_filter` with no luck, and fell back to the `IVSHMEM` solution, which is polling, resulting in less than ideal latency for gaming.

With this PR, you can run scream unix receiver in pcap mode with `scream -P -i macvtap0` and if you have `uid/gid` issues due to a hard requirement to be a specific user for your `pulseaudio`/`alsa` setup, you can do `setcap cap_net_raw,cap_net_admin=eip ./scream` as `root` and give it the capabilities it needs to capture packets without being root. I am relatively sure this can be narrowed down to specific interfaces or ports if need be.

Let me know if you have any questions. In my VFIO setup, with this I see a 3x reduction in audio latency compared to the IVSHMEM.

I will be experimenting with eBPF for further latency improvements.

This primarily enables people having issues with multicast UDP not getting delivered to the user-space applications for various reasons but has the additional benefit of allowing VFIO users to utilize their `macvtap` setup without having to take the convoluted path of `vm -> macvtap -> eth0 -> router -> eth0`.