### PR TITLE
Added unix receiver option to define Pulseaudio sink

### DIFF
--- a/Receivers/unix/pulseaudio.c
+++ b/Receivers/unix/pulseaudio.c
@@ -8,10 +8,11 @@ static struct pulse_output_data {
 
   receiver_format_t receiver_format;
   int latency;
+  char *sink;
   char *stream_name;
 } po_data;
 
-int pulse_output_init(int latency, char *stream_name)
+int pulse_output_init(int latency, char *sink, char *stream_name)
 {
   int error;
 
@@ -33,6 +34,7 @@ int pulse_output_init(int latency, char *stream_name)
   po_data.receiver_format.channel_map = 0x0003;
 
   po_data.latency = latency;
+  po_data.sink = sink;
   po_data.stream_name = stream_name;
 
   // set buffer size for requested latency
@@ -45,7 +47,7 @@ int pulse_output_init(int latency, char *stream_name)
   po_data.s = pa_simple_new(NULL,
     "Scream",
     PA_STREAM_PLAYBACK,
-    NULL,
+    po_data.sink,
     po_data.stream_name,
     &po_data.ss,
     &po_data.channel_map,
@@ -162,7 +164,7 @@ int pulse_output_send(receiver_data_t *data)
       po_data.s = pa_simple_new(NULL,
         "Scream",
         PA_STREAM_PLAYBACK,
-        NULL,
+        po_data.sink,
         po_data.stream_name,
         &po_data.ss,
         &po_data.channel_map,

--- a/Receivers/unix/pulseaudio.h
+++ b/Receivers/unix/pulseaudio.h
@@ -10,7 +10,7 @@
 
 #include "scream.h"
 
-int pulse_output_init(int latency, char *stream_name);
+int pulse_output_init(int latency, char *sink, char *stream_name);
 int pulse_output_send(receiver_data_t *data);
 
 #endif

--- a/Receivers/unix/scream.c
+++ b/Receivers/unix/scream.c
@@ -203,7 +203,7 @@ int main(int argc, char*argv[]) {
     case Pulseaudio:
 #if PULSEAUDIO_ENABLE
       if (verbosity) fprintf(stderr, "Using Pulseaudio output\n");
-      if (pulse_output_init(target_latency_ms, stream_name) != 0) {
+      if (pulse_output_init(target_latency_ms, sink, stream_name) != 0) {
         return 1;
       }
       output_send_fn = pulse_output_send;

--- a/Receivers/unix/scream.c
+++ b/Receivers/unix/scream.c
@@ -53,6 +53,7 @@ static void show_usage(const char *arg0)
   fprintf(stderr, "\n");
   fprintf(stderr, "         -o pulse|alsa|raw         : Send audio to PulseAudio, ALSA, or stdout.\n");
   fprintf(stderr, "         -d <device>               : ALSA device name. 'default' if not specified.\n");
+  fprintf(stderr, "         -s <sink name>            : Pulseaudio sink name.\n");
   fprintf(stderr, "         -n <stream name>          : Pulseaudio stream name/description.\n");
   fprintf(stderr, "         -t <latency>              : Target latency in milliseconds. Defaults to 50ms.\n");
   fprintf(stderr, "                                     Only relevant for PulseAudio and ALSA output.\n");
@@ -129,12 +130,13 @@ int main(int argc, char*argv[]) {
   char *output               = NULL;
   const char* interface_name = NULL;
   char *alsa_device          = "default";
+  char *sink                 = NULL;
   char *stream_name          = "Audio";
   int target_latency_ms      = 50;
   in_addr_t interface        = INADDR_ANY;
   uint16_t port              = DEFAULT_PORT;
   int opt;
-  while ((opt = getopt(argc, argv, "i:g:p:m:x:o:d:n:t:Puvh")) != -1) {
+  while ((opt = getopt(argc, argv, "i:g:p:m:x:o:d:s:n:t:Puvh")) != -1) {
     switch (opt) {
     case 'i':
       interface_name = strdup(optarg);
@@ -164,6 +166,9 @@ int main(int argc, char*argv[]) {
       break;
     case 'd':
       alsa_device = strdup(optarg);
+      break;
+    case 's':
+      sink = strdup(optarg);
       break;
     case 'n':
       stream_name = strdup(optarg);


### PR DESCRIPTION
The current implementation selects the default sink of Pulseaudio as audio output.
There was no possibility to select a specific sink.
The option "-s <sink name>" need to be passed to the command line to select the sink.
If no sink is defined then the default sink is used, which is the same behavior as before.

