### PR TITLE
Fix installer failure on different drives

### DIFF
--- a/Install/Install.bat
+++ b/Install/Install.bat
@@ -2,6 +2,7 @@
 net session >nul 2>&1
 if %errorLevel% == 0 (
   cd %~dp0\driver
+  %~d0
   ..\helpers\devcon remove '*Scream >nul 2>&1
   ..\helpers\devcon install Scream.inf *Scream
 ) else (


### PR DESCRIPTION
Windows keeps track of the current working directory for each drive
separately.  With RMB -> Run as Admin, the script starts off in
`C:\Windows\system32`; if the installer lives on a different drive (e.g.
D:), we need to explicitly change to that drive as well as changing the
CWD on it.