### PR TITLE
JACK adjustable ringbuffer and return statement fix

### DIFF
--- a/Receivers/unix/jack.c
+++ b/Receivers/unix/jack.c
@@ -328,6 +328,7 @@ static int connect_ports()
   }
 
   jack_free(ports);
+  return 0;
 }
 
 

--- a/Receivers/unix/jack.h
+++ b/Receivers/unix/jack.h
@@ -3,7 +3,7 @@
 
 #include "scream.h"
 
-int jack_output_init(char *stream_name);
+int jack_output_init(int latency, char *stream_name);
 int jack_output_send(receiver_data_t *data);
 
 #endif

--- a/Receivers/unix/scream.c
+++ b/Receivers/unix/scream.c
@@ -237,7 +237,7 @@ int main(int argc, char*argv[]) {
     case Jack:
 #if JACK_ENABLE
       if (verbosity) fprintf(stderr, "Using JACK output\n");
-      if (jack_output_init(jack_client_name) != 0) {
+      if (jack_output_init(target_latency_ms, jack_client_name) != 0) {
         return 1;
       }
       output_send_fn = jack_output_send;


### PR DESCRIPTION
this fixes a bug where the return value for connect_ports could be arbitrary when it successfully connects to an audio device, either 0 or not 0 which always had been not 0 in my case. this also adds an adjustable ringbuffer that adapts to changes in audio and given latency since the fixed size ringbuffer was not dealing well with my setup.