### PR TITLE
Add a warning on IVSHMEM to README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,11 @@ Tweak the registry in the manner depicted in this screenshot
 
 Using IVSHMEM between Windows guest and Linux host
 -------------------------------------------------------------
+_**Note:** While this setup is possible, it is generally ill-advised. 
+Scream on QEMU does not benefit from using IVSHMEM.  
+If anything, it increases CPU load and latency due to the polling nature of the implementation.  
+Scream in QEMU operates far better over a standard virtio-net device._
+
 This can be used as an alternative to the default networked
 transfer when using QEMU/KVM.
 - Add a IVSHMEM device to your VM. We recommend a size of 2MB.


### PR DESCRIPTION
To quote the [Looking Glass wiki](https://looking-glass.io/wiki/Using_Scream):
> Note: While this setup is possible it is ill-advised, Scream does not benefit from using IVSHMEM in any way, if anything it increases CPU load and latency due to the polling nature of the implementation. Scream operates far better over a vfio-net device which is already a zero-copy data transfer via shared memory.

Scream over (virtio) networking is better in every scenario, except when the guest has no networking at all, or otherwise _cannot_ use the network for Scream.

The current documentation does not make this clear, and we frequently see people in the VFIO Discord server needlessly running into issues with Scream IVSHMEM, where they shouldn't have been using this in the first place.
Rather than explaining to people daily why this setup isn't optimal, it would be better to tackle this problem at the source, the Scream documentation.