### PR TITLE
Hacky patch for avoiding a crash on Unix receivers

### DIFF
--- a/Receivers/unix/scream.c
+++ b/Receivers/unix/scream.c
@@ -285,6 +285,7 @@ int main(int argc, char*argv[]) {
     receiver_rcv_fn(&receiver_data);
     if (receiver_data.format.channels == 0) {
         // Invalid data, loop again
+        if (verbosity) fprintf(stderr, "Received invalid data, trying again\n");
         continue;
     }
     if (output_send_fn(&receiver_data) != 0)

--- a/Receivers/unix/scream.c
+++ b/Receivers/unix/scream.c
@@ -283,6 +283,10 @@ int main(int argc, char*argv[]) {
 
   for (;;) {
     receiver_rcv_fn(&receiver_data);
+    if (receiver_data.format.channels == 0) {
+        // Invalid data, loop again
+        continue;
+    }
     if (output_send_fn(&receiver_data) != 0)
       return 1;
   }


### PR DESCRIPTION
This is my uninformed attempt at fixing #117. Essentially, since the error only occurs if we have 0 channels, and that doesn't make sense anyways, simply discarding the troublesome data is better than crashing.

I think there is something wrong with how the data is being sent from windows, or the way that the network code is written, but I don't have a ton of experience with Windows development.