### PR TITLE
Prevent usage of uninitialized g_silenceThreshold

### DIFF
--- a/Scream/adapter.cpp
+++ b/Scream/adapter.cpp
@@ -145,7 +145,12 @@ Returns:
         // Don't return error because we will operate with default values.
     }
 
-    g_silenceThreshold = silenceThreshold;
+    if (silenceThreshold > 0) {
+        g_silenceThreshold = silenceThreshold;
+    }
+    else {
+        g_silenceThreshold = 0;
+    }
 
     if (unicastPort > 0) {
         g_UnicastPort = unicastPort;


### PR DESCRIPTION
Small fix to prevent BSOD on my test env (Windows 7 x86)

![image](https://user-images.githubusercontent.com/5537710/126995288-5ddc43dd-22c8-4fe0-a00f-a222c417c0f6.png)


