### PR TITLE
Don't mix channels with silence suppression on

### DIFF
--- a/Scream/minstream.cpp
+++ b/Scream/minstream.cpp
@@ -131,6 +131,7 @@ Return Value:
         m_usBlockAlign                    = pWfx->nBlockAlign;
         m_fFormat16Bit                    = (pWfx->wBitsPerSample == 16);
         m_bitsPerSample                   = pWfx->wBitsPerSample;
+        m_bChannels                       = pWfx->nChannels;
         m_ksState                         = KSSTATE_STOP;
         m_ulDmaPosition                   = 0;
         m_ullElapsedTimeCarryForward      = 0;
@@ -671,7 +672,7 @@ Return Value:
                     if (!current_sample_is_silent) {
                         // State transition: Silent -> Not Silent
                         m_silenceState = 0;
-                        start_copy_byte = i * bytes_per_sample;
+                        start_copy_byte = (i / m_bChannels) * m_bChannels * bytes_per_sample;
                     }
                 }
                 else if (m_silenceState > 0) {
@@ -682,7 +683,7 @@ Return Value:
                             // State transition: Gap -> Silent
 
                             // Need to write out whatever has occurred so far
-                            m_SaveData.WriteData(((PBYTE)Source + start_copy_byte), (i * bytes_per_sample) - start_copy_byte);
+                            m_SaveData.WriteData(((PBYTE)Source + start_copy_byte), ((i / m_bChannels) * m_bChannels * bytes_per_sample) - start_copy_byte);
                         }
                     }
                     else {

--- a/Scream/minstream.h
+++ b/Scream/minstream.h
@@ -54,6 +54,7 @@ protected:
     ULONGLONG                   m_silenceState = 0;                 // 0 = Not Silent, >g_silenceThreshold=Silent,
                                                                     // values lower than threshold = Gap
     WORD                        m_bitsPerSample;
+    BYTE                        m_bChannels;
    
 public:
     DECLARE_STD_UNKNOWN();


### PR DESCRIPTION
Make sure we don't start / stop sending samples in between channels. This should fix #148, at least the silence suppression part. I couldn't check if sleep / hibernation is also fixed, since I haven't encountered that case myself.