### PR TITLE
Added 88.2KHz Sample Rate

### DIFF
--- a/Scream/minwave.cpp
+++ b/Scream/minwave.cpp
@@ -520,7 +520,7 @@ Return Value:
                     WAVEFORMATEX* pWfx = (WAVEFORMATEX*)&pKsFormat->WaveFormatEx;
                     // We support from 1 to 8 channels at freq >= 44100, sampling size >= 16bits
                     if ( ((pWfx->wBitsPerSample == 16) || (pWfx->wBitsPerSample == 24) || (pWfx->wBitsPerSample == 32)) &&
-                         ((pWfx->nSamplesPerSec == 44100) || (pWfx->nSamplesPerSec == 48000) || (pWfx->nSamplesPerSec == 96000) || (pWfx->nSamplesPerSec == 192000)) ) {
+                         ((pWfx->nSamplesPerSec == 44100) || (pWfx->nSamplesPerSec == 48000) || (pWfx->nSamplesPerSec == 88200) || (pWfx->nSamplesPerSec == 96000) || (pWfx->nSamplesPerSec == 192000)) ) {
                         if ((pWfx->wFormatTag == WAVE_FORMAT_PCM) && (pWfx->cbSize == 0)) {
                             if ((pWfx->nChannels >= 1) && (pWfx->nChannels <= 8)) {
                                 ntStatus = STATUS_SUCCESS;


### PR DESCRIPTION
This is particularly needed to allow MQA-enabled apps to have exclusive access to the audio device. MQA rendering uses 88.2Khz and 96Khz for 44.1Khz and 48Khz-encoded tracks, respectively.

Tidal can now have exclusive access to it and render correctly.

Tested using the Linux Renderer app which successfully changes the sample rate to 88200:

![Scream 88200Hz mode](https://user-images.githubusercontent.com/16326634/190718271-f09e0802-d0b4-4ce8-b556-db3208440756.png)
![Scream Linux Renderer 88200Hz](https://user-images.githubusercontent.com/16326634/190718279-09110585-de23-417e-a456-a75c755b50d7.png)
