### PR TITLE
Unregister jack ports before creating new ones

### DIFF
--- a/Receivers/unix/jack.c
+++ b/Receivers/unix/jack.c
@@ -101,6 +101,7 @@ static struct jack_output_data
   size_t              resample_buffer_size;
   struct ringbuffer_t rb;
   int latency;
+  int connect;
 }
 jo_data;
 
@@ -116,7 +117,7 @@ int jack_process(jack_nframes_t nframes, void *arg);
 
 
 
-int jack_output_init(int latency, char *stream_name)
+int jack_output_init(int latency, char *stream_name, int connect)
 {
   jack_status_t status;
 
@@ -130,6 +131,7 @@ int jack_output_init(int latency, char *stream_name)
   jo_data.resample_buffer = NULL;
   jo_data.resample_buffer_size = 0;
   jo_data.latency = latency;
+  jo_data.connect = connect;
   jo_data.rb.elements = NULL;
 
   jo_data.client = jack_client_open(stream_name, JackNullOption, &status, NULL);
@@ -206,9 +208,10 @@ int jack_output_send(receiver_data_t *data)
       return 1;
     }
 
-    if (connect_ports())
+    if (jo_data.connect)
     {
-      return 1;
+      if (connect_ports())
+        return 1;
     }
 
     if (jo_data.rb.elements != NULL)

--- a/Receivers/unix/jack.c
+++ b/Receivers/unix/jack.c
@@ -92,6 +92,7 @@ static struct jack_output_data
 {
   jack_client_t       *client;
   jack_port_t         **output_ports;   ///< number of ports actually used == rf->channels
+  uint32_t            num_output_ports;
   jack_default_audio_sample_t **buffers;
   receiver_format_t   receiver_format;
   uint32_t            sample_rate;      ///< source sample rate
@@ -286,8 +287,15 @@ static const char *channel_index_to_name(uint8_t channel)
 
 static int init_channels()
 {
+  if (jo_data.output_ports)
+  {
+    for (uint32_t i = 0 ; i < jo_data.num_output_ports; ++i)
+      jack_port_unregister(jo_data.client, jo_data.output_ports[i]);
+  }
+
   free(jo_data.output_ports);
-  jo_data.output_ports = malloc(sizeof(jack_port_t*) * jo_data.receiver_format.channels);
+  jo_data.num_output_ports = jo_data.receiver_format.channels;
+  jo_data.output_ports = malloc(sizeof(jack_port_t*) * jo_data.num_output_ports);
   free(jo_data.buffers);
   jo_data.buffers = malloc(sizeof(jack_default_audio_sample_t*) * jo_data.receiver_format.channels);
   for (int i = 0 ; i < jo_data.receiver_format.channels; ++i)

--- a/Receivers/unix/jack.h
+++ b/Receivers/unix/jack.h
@@ -3,7 +3,7 @@
 
 #include "scream.h"
 
-int jack_output_init(int latency, char *stream_name);
+int jack_output_init(int latency, char *stream_name, int connect);
 int jack_output_send(receiver_data_t *data);
 
 #endif

--- a/Receivers/unix/scream.c
+++ b/Receivers/unix/scream.c
@@ -69,6 +69,7 @@ static void show_usage(const char *arg0)
   fprintf(stderr, "                                        Only relevant for PulseAudio and ALSA output.\n");
   fprintf(stderr, "         -l <latency>                 : Max latency in milliseconds. Defaults to 200ms.\n");
   fprintf(stderr, "                                        Only relevant for PulseAudio output.\n");
+  fprintf(stderr, "         -c                           : Do not connect jack ports.\n");
   fprintf(stderr, "\n");
   fprintf(stderr, "         -v                           : Be verbose.\n");
   fprintf(stderr, "\n");
@@ -154,9 +155,10 @@ int main(int argc, char*argv[]) {
   int max_latency_ms         = 100;
   in_addr_t interface        = INADDR_ANY;
   uint16_t port              = DEFAULT_PORT;
+  int jack_connect           = 1;
   int opt;
   
-  while ((opt = getopt(argc, argv, "i:g:p:m:x:o:d:s:n:t:l:Puvh")) != -1) {
+  while ((opt = getopt(argc, argv, "i:g:p:m:x:o:d:s:n:t:l:Puvhc")) != -1) {
     switch (opt) {
     case 'i':
       interface_name = strdup(optarg);
@@ -209,6 +211,9 @@ int main(int argc, char*argv[]) {
       max_latency_ms = atoi(optarg);
       if (max_latency_ms < 0) show_usage(argv[0]);
       break;
+    case 'c':
+      jack_connect = 0;
+      break;
     case 'v':
       verbosity += 1;
       break;
@@ -259,7 +264,7 @@ int main(int argc, char*argv[]) {
     case Jack:
 #if JACK_ENABLE
       if (verbosity) fprintf(stderr, "Using JACK output\n");
-      if (jack_output_init(target_latency_ms, jack_client_name) != 0) {
+      if (jack_output_init(target_latency_ms, jack_client_name, jack_connect) != 0) {
         return 1;
       }
       output_send_fn = jack_output_send;


### PR DESCRIPTION
In the jack receiver, before creating jack ports because of a configuration change, the old ports should be unregistered.
If this is not done, creating new ports will fail, because the old ports still exist and have the same names.

I've also added a -c command line switch to disable automatically connecting jack ports, for people who use their own jack connection manager.