### PR TITLE
Fixed compile errors due to misnamed buffersize variable

### DIFF
--- a/Receivers/unix/pcap.h
+++ b/Receivers/unix/pcap.h
@@ -6,7 +6,7 @@
 #include <pcap.h>
 #include <ctype.h>
 
-#define PCAP_BUFSIZ PCAP_BUF_SIZE * 8
+#define PCAP_BUFSIZ PCAP_ERRBUF_SIZE * 8
 #define SIZE_ETHERNET 14
 
 /* Ethernet addresses are 6 bytes */


### PR DESCRIPTION
After facing compille issues on Ubuntu 16.04 LTS about undefined variable, I found the following in line 21 in `pcap.c`:
> snprintf(filter_exp, PCAP_ERRBUF_SIZE, "udp port %d", port);

suggesting perhaps that the declaration should be `PCAP_ERRBUF_SIZE` instead of `PCAP_BUF_SIZE`. After changing this, the compilation worked and the program runs without issues so far.