### PR TITLE
receiver: make verbosity accessible from other files

### DIFF
--- a/Receivers/unix/scream.c
+++ b/Receivers/unix/scream.c
@@ -40,6 +40,8 @@
 #include "sndio.h"
 #endif
 
+int verbosity = 0;
+
 static void show_usage(const char *arg0)
 {
   fprintf(stderr, "\n");

--- a/Receivers/unix/scream.h
+++ b/Receivers/unix/scream.h
@@ -24,6 +24,6 @@ typedef struct receiver_data {
   unsigned char* audio;
 } receiver_data_t;
 
-static int verbosity = 0;
+extern int verbosity;
 
 #endif


### PR DESCRIPTION
Using 'static' makes each file that includes this header have their own 'verbosity' variable, making the '-v' option not take effect for any file other than 'scream.c'.

This is an existing issue where the '-v' flag will not cause the statement in 'alsa.c' to be printed.